### PR TITLE
fixed TrimLeft usage to TrimPrefix for us to not miss characters

### DIFF
--- a/container/kube/kubectl.go
+++ b/container/kube/kubectl.go
@@ -85,7 +85,7 @@ func (kube KubeCli) GetInfo(ctx context.Context, cid string) types.Container {
 }
 
 func trimContainerIDPrefix(id string) string {
-	return strings.TrimLeft(id, "docker://")
+	return strings.TrimPrefix(id, "docker://")
 }
 
 func containerReady(ready bool) string {


### PR DESCRIPTION
Hi Guys,

Found an issue in Kubernetes connector that affects enumerated containers.
I used TrimPrefix instead of TrimLeft function because TrimLeft has removed in some cases characters in ContainerID hash.

Here is a simple example that showcases the reason for the change: https://play.golang.org/p/B2FD7C4rpuW

