### PR TITLE
fix read closed `activeChan` when timeout is set

### DIFF
--- a/route/exec.go
+++ b/route/exec.go
@@ -146,7 +146,10 @@ func (server *Server) processTTY(ctx context.Context, execID string, timeoutCanc
 					timer.Stop()
 					timeoutCancel()
 					return
-				case <-activeChan:
+				case _, ok := <-activeChan:
+					if !ok {
+						return
+					}
 					// the connection is active, reset the timer
 					timer.Reset(tout)
 				}


### PR DESCRIPTION
设置timeout然后断开连接，activeChan被关闭但不会退出timeout的for循环，cpu跑满一核