### PR TITLE
Modified client to use environment variables

### DIFF
--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -28,31 +28,20 @@ func NewCli(conf config.DockerConfig) (*DockerCli, error) {
 	host := conf.DockerHost
 	if host[:1] == "/" {
 		host = "unix://" + host
-	} else {
+	} else if !strings.HasPrefix(host, "tcp://") {
 		host = "tcp://" + host
 	}
-	//version := "v1.24"
+
 	logrus.Infof("Docker connecting to %s", host)
-	//UA := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	//cli, err := client.NewClient(host, version, nil, UA)
+
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		logrus.Errorf("create new docker client error: %s", err)
 		return nil, err
 	}
 
-	// update docker version
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	//v, err := cli.ServerVersion(ctx)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//cli, err = client.NewClient(host, v.APIVersion, nil, UA)
-	//if err != nil {
-	//	logrus.Errorf("create new docker client error: %s", err)
-	//	return nil, err
-	// }
 
 	listOptions, err := buildListOptions(conf.PsOptions)
 	if err != nil {

--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -31,10 +31,11 @@ func NewCli(conf config.DockerConfig) (*DockerCli, error) {
 	} else {
 		host = "tcp://" + host
 	}
-	version := "v1.24"
+	//version := "v1.24"
 	logrus.Infof("Docker connecting to %s", host)
-	UA := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient(host, version, nil, UA)
+	//UA := map[string]string{"User-Agent": "engine-api-cli-1.0"}
+	//cli, err := client.NewClient(host, version, nil, UA)
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		logrus.Errorf("create new docker client error: %s", err)
 		return nil, err
@@ -43,15 +44,15 @@ func NewCli(conf config.DockerConfig) (*DockerCli, error) {
 	// update docker version
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	v, err := cli.ServerVersion(ctx)
-	if err != nil {
-		return nil, err
-	}
-	cli, err = client.NewClient(host, v.APIVersion, nil, UA)
-	if err != nil {
-		logrus.Errorf("create new docker client error: %s", err)
-		return nil, err
-	}
+	//v, err := cli.ServerVersion(ctx)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//cli, err = client.NewClient(host, v.APIVersion, nil, UA)
+	//if err != nil {
+	//	logrus.Errorf("create new docker client error: %s", err)
+	//	return nil, err
+	// }
 
 	listOptions, err := buildListOptions(conf.PsOptions)
 	if err != nil {


### PR DESCRIPTION
Modified the go docker client in `container/docker/docker.go` to call `client.NewClientWithOpts(client.FromEnv)`, which enables the go client to connect to docker with the environment variables of the system. 

With this modification a TLS connection to the docker daemon is possible and there is no need to mount `docker.sock` anymore. 

For example, you may now run the following compose file, where a web-tty is attached to a docker-in-docker container.

```
networks:
  dind:

volumes:
  docker-certs-ca:
  docker-certs-client:

services:
  daemon:
    image: docker:dind
    privileged: true
    environment:
      - DOCKER_TLS_CERTDIR=/certs
    volumes:
      - docker-certs-ca:/certs/ca
      - docker-certs-client:/certs/client
    networks:
      dind:
        aliases:
          - docker

  web-tty:
    image: wrfly/container-web-tty:latest
    depends_on:
      - daemon
    ports:
      - 8080:8080
    networks:
      - dind
    environment:
      - WEB_TTY_DEBUG=false
      - DOCKER_TLS_VERIFY=1
      - DOCKER_TLS_CERTDIR=/certs
      - DOCKER_CERT_PATH=/certs/client
      - DOCKER_HOST=tcp://docker:2376
    volumes:
      - docker-certs-client:/certs/client:ro
     
```